### PR TITLE
[PHP-FPM 8.0]Bump `apcu` extension from 5.1.21 to 5.1.22

### DIFF
--- a/8.0/fpm/Dockerfile
+++ b/8.0/fpm/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get -y install git libjpeg-dev libmagickwand-dev \
 RUN docker-php-ext-configure gd --with-jpeg && docker-php-ext-install bcmath \
     gd intl opcache pcntl pdo pdo_mysql pdo_pgsql pdo_sqlite soap sockets zip
 
-RUN pecl install apcu-5.1.21 ast-1.0.16 imagick-3.7.0 memcached-3.2.0 \
+RUN pecl install apcu-5.1.22 ast-1.0.16 imagick-3.7.0 memcached-3.2.0 \
     mongodb-1.14.1 uuid-1.2.0 redis-5.3.7 && docker-php-ext-enable ast apcu \
     imagick memcached mongodb uuid redis
 


### PR DESCRIPTION
Signed-off-by: Nathanael Esayeas <nathanael.esayeas@protonmail.com>
