### PR TITLE
Update docker/metadata-action to version v6

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           github-token: ${{ secrets.GHT }}
           images: ${{ env.DEFAULT_IMAGE }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           github-token: ${{ secrets.GHT }}
           images: ${{ env.DEFAULT_IMAGE }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           github-token: ${{ secrets.GHT }}
           images: ${{ env.DEFAULT_IMAGE }}


### PR DESCRIPTION
Updates the `docker/metadata-action` GitHub Action to version `v6`.

This pull request changes the following file(s): 

- Update `ter/php/.github/workflows/docker-build-push.yml`