### PR TITLE
Update actions/checkout to version v7

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -28,7 +28,7 @@ jobs:
     container:
       image: php:8.5-cli-alpine
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: matrix
         run: echo "matrix=$(php script/matrix.php)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Updates the `actions/checkout` GitHub Action to version `v7`.

This pull request changes the following file(s): 

- Update `ter/php/.github/workflows/docker-build-push.yml`